### PR TITLE
Add Paseo Hub workflow section

### DIFF
--- a/content/posts/paseo-visual-agent-orchestration.md
+++ b/content/posts/paseo-visual-agent-orchestration.md
@@ -87,6 +87,14 @@ That is the difference that makes Paseo practical for me. I am not choosing an A
 
 The visual interface still matters, of course. But in my setup, the requirement that changes the decision is being able to operate my own devices.
 
+## Adding Workflows with Hub
+
+[Paseo Hub](https://github.com/getpaseo/hub) is a self-hosted automation layer for Paseo. It can start coding agents from GitHub, Slack, Discord, or a manual run, then dispatch them to the Paseo daemons on the machines you already own.
+
+That is an interesting extension of the setup I want: not just a visual tool I open when I sit down, but a way for work that arrives in Discord or GitHub to trigger the right workflow on the right machine. Hub keeps its triggers, environments, permissions, and prompts in version-controlled `.paseo/hub.yml` and `.paseo/workflows/` files.
+
+It is still in early development; Hub’s README warns that breaking changes and data loss are possible. I would treat it as something to experiment with rather than production infrastructure for now.
+
 ## Why Open Source Changes How I Use It
 
 The maintainer is also serious about keeping Paseo open source. As he has described it, the plan is to keep everything open source—including the relay—while fully supporting self-hosting and offering paid hosted services for people who want that option. That combination matters to me: it keeps self-hosting as a first-class option without taking away the convenience of a hosted service.


### PR DESCRIPTION
## Summary

- Add an “Adding Workflows with Hub” section to the Paseo post.
- Link to Paseo Hub and describe its self-hosted GitHub, Slack, Discord, and manual-run workflows.
- Explain that Hub dispatches work to existing Paseo daemons and keeps workflow configuration in version control.
- Include Hub’s early-development warning so readers do not mistake it for production-ready infrastructure.

## Why

This extends the post from hands-on multi-device agent control to workflows that can begin where work arrives, while preserving the author’s practical, self-hosted framing.

## Validation

- `git diff --check`
- Production Hugo build with repository-pinned Hugo `0.146.0` (`--gc --minify`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a single Hugo post; no application code, config, or build logic is modified.
> 
> **Overview**
> Adds a new **“Adding Workflows with Hub”** section to the Paseo orchestration post, placed after the multi-device / agent-orchestration narrative and before the open-source section.
> 
> The section introduces [Paseo Hub](https://github.com/getpaseo/hub) as a self-hosted automation layer that can start agents from GitHub, Slack, Discord, or manual runs and dispatch them to existing Paseo daemons. It notes that triggers, environments, permissions, and prompts live in version-controlled `.paseo/hub.yml` and `.paseo/workflows/` files, and includes Hub’s early-development caveat so readers treat it as experimental rather than production infrastructure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 370a9f8df00ea87392eccb80b5d7a48b61f5eb15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added information about Paseo Hub, a self-hosted automation layer for triggering coding agents from GitHub, Slack, Discord, or manual runs.
  - Documented dispatching tasks to owned Paseo daemons and managing configuration through version-controlled files.
  - Noted the project’s early-development status, including possible breaking changes and data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->